### PR TITLE
Set redis service var

### DIFF
--- a/namespaced/kustomization.yaml
+++ b/namespaced/kustomization.yaml
@@ -11,3 +11,11 @@ patchesStrategicMerge:
 images:
   - name: argoproj/argocd
     newTag: v1.6.1
+vars:
+  - name: ARGOCD_REDIS_SERVICE
+    objref:
+      kind: Service
+      name: argocd-redis
+      apiVersion: v1
+    fieldref:
+      fieldpath: metadata.name


### PR DESCRIPTION
The upstream manifests set ARGOCD_REDIS_SERVICE to the name of the redis service, which is then substituted in the args of the repo server.

As we're building each base separately from upstream to avoid pulling in dex, we're missing this var.